### PR TITLE
Bump bindgen to 0.60

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,6 @@ keywords = ["nfs"]
 categories = ["api-bindings", "network-programming", "filesystem", "external-ffi-bindings"]
 
 [build-dependencies]
-bindgen = "~0.46"
+bindgen = "0.60"
 
 [dependencies]


### PR DESCRIPTION
0.46 does not understand `BINDGEN_EXTRA_CLANG_ARGS` env var which is required to build bindgen projects on NixOS