### PR TITLE
Improve include path configuration

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -25,14 +25,27 @@ fn main() {
         },
         Err(_) => {},
     }
+
     // The bindgen::Builder is the main entry point
     // to bindgen, and lets you build up options for
     // the resulting bindings.
-    let bindings = bindgen::Builder::default()
+    let mut builder = bindgen::Builder::default()
     // The input header we would like to generate
     // bindings for.
-    .header("wrapper.h")
+    .header("wrapper.h");
+    
+    let libnfs_include_path_if_any = env::var("LIBNFS_INCLUDE_PATH");
+    match libnfs_include_path_if_any {
+        Ok(include_path) => {
+            let include_path = Path::new(&include_path);
+            builder = builder.clang_arg(format!("-I{}", include_path.display()));
+
+        },
+        Err(_) => {},
+    }
+
     //.blacklist_type("statvfs")
+    let bindings = builder
     // Finish the builder and generate the bindings.
     .generate()
     // Unwrap the Result and panic on failure.

--- a/wrapper.h
+++ b/wrapper.h
@@ -1,6 +1,7 @@
 #if defined(__aarch64__) && !defined(__arm64__)
 #define __arm64__ 1
 #endif
+#include <stddef.h>
 #include <sys/statvfs.h>
 #include <sys/time.h>
 #include <nfsc/libnfs.h>


### PR DESCRIPTION
Add environment variable LIBNFS_INCLUDE_PATH for custom header path for libnfs
Adding including stddef.h for better compatibility of compilation with custom include path on Linux